### PR TITLE
OnPropertyChanged() calls in every property setter

### DIFF
--- a/CalorieTracker/Models/Product.cs
+++ b/CalorieTracker/Models/Product.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CalorieTracker.Models
 {
@@ -21,51 +18,31 @@ namespace CalorieTracker.Models
         public string Name
         {
             get => _name;
-            set
-            {
-                _name = value;
-                OnPropertyChanged();
-            }
+            set => SetField(ref _name, value);
         }
 
         public double CaloriesPerGram
         {
             get => _caloriesPerGram;
-            set
-            {
-                _caloriesPerGram = value;
-                OnPropertyChanged();
-            }
+            set => SetField(ref _caloriesPerGram, value);
         }
 
         public double Protein
         {
             get => _protein;
-            set
-            {
-                _protein = value;
-                OnPropertyChanged();
-            }
+            set => SetField(ref _protein, value);
         }
 
         public double Carbs
         {
             get => _carbs;
-            set
-            {
-                _carbs = value;
-                OnPropertyChanged();
-            }
+            set => SetField(ref _carbs, value);
         }
 
         public double Fat
         {
             get => _fat;
-            set
-            {
-                _fat = value;
-                OnPropertyChanged();
-            }
+            set => SetField(ref _fat, value);
         }
 
         public ProductCategory Category { get; set; }
@@ -75,6 +52,14 @@ namespace CalorieTracker.Models
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
         }
     }
 


### PR DESCRIPTION
Problem:
The Product class had repetitive OnPropertyChanged() calls in every property setter, reducing maintainability and readability.

Changes:
Introduced generic SetField<T>() method to handle value assignment and property change notification in one place.

Replaced all property setters to use SetField.

Benefits:
🔄 DRY principle enforced

🧹 Cleaner, more maintainable code

📉 Fewer chances of bugs in property change tracking